### PR TITLE
Have Box<dyn Model> serialization add the 'type' field appropriately

### DIFF
--- a/src/models/exclusive_gateway.rs
+++ b/src/models/exclusive_gateway.rs
@@ -3,7 +3,7 @@ use std::f64::INFINITY;
 
 use serde::{Deserialize, Serialize};
 
-use super::model::Model;
+use super::model::{Model, Type};
 use super::ModelMessage;
 use crate::input_modeling::random_variable::IndexRandomVariable;
 use crate::input_modeling::uniform_rng::UniformRNG;
@@ -108,6 +108,10 @@ impl Model for ExclusiveGateway {
 
     fn id(&self) -> String {
         self.id.clone()
+    }
+
+    fn get_type(&self) -> Type {
+        Type::ExclusiveGateway
     }
 
     fn status(&self) -> String {

--- a/src/models/gate.rs
+++ b/src/models/gate.rs
@@ -3,7 +3,7 @@ use std::f64::INFINITY;
 
 use serde::{Deserialize, Serialize};
 
-use super::model::Model;
+use super::model::{Model, Type};
 use super::ModelMessage;
 use crate::input_modeling::uniform_rng::UniformRNG;
 use crate::utils::error::SimulationError;
@@ -131,6 +131,10 @@ impl Model for Gate {
 
     fn id(&self) -> String {
         self.id.clone()
+    }
+
+    fn get_type(&self) -> Type {
+        Type::Gate
     }
 
     fn status(&self) -> String {

--- a/src/models/generator.rs
+++ b/src/models/generator.rs
@@ -3,7 +3,7 @@ use std::f64::INFINITY;
 
 use serde::{Deserialize, Serialize};
 
-use super::model::Model;
+use super::model::{Model, Type};
 use super::ModelMessage;
 use crate::input_modeling::random_variable::ContinuousRandomVariable;
 use crate::input_modeling::thinning::Thinning;
@@ -121,6 +121,10 @@ impl Model for Generator {
 
     fn id(&self) -> String {
         self.id.clone()
+    }
+
+    fn get_type(&self) -> Type {
+        Type::Generator
     }
 
     fn status(&self) -> String {

--- a/src/models/load_balancer.rs
+++ b/src/models/load_balancer.rs
@@ -3,7 +3,7 @@ use std::f64::INFINITY;
 
 use serde::{Deserialize, Serialize};
 
-use super::model::Model;
+use super::model::{Model, Type};
 use super::ModelMessage;
 use crate::input_modeling::uniform_rng::UniformRNG;
 use crate::utils::error::SimulationError;
@@ -107,6 +107,10 @@ impl Model for LoadBalancer {
 
     fn id(&self) -> String {
         self.id.clone()
+    }
+
+    fn get_type(&self) -> Type {
+        Type::LoadBalancer
     }
 
     fn status(&self) -> String {

--- a/src/models/parallel_gateway.rs
+++ b/src/models/parallel_gateway.rs
@@ -4,7 +4,7 @@ use std::f64::INFINITY;
 
 use serde::{Deserialize, Serialize};
 
-use super::model::Model;
+use super::model::{Model, Type};
 use super::ModelMessage;
 use crate::input_modeling::uniform_rng::UniformRNG;
 use crate::utils::error::SimulationError;
@@ -113,6 +113,10 @@ impl Model for ParallelGateway {
 
     fn id(&self) -> String {
         self.id.clone()
+    }
+
+    fn get_type(&self) -> Type {
+        Type::ParallelGateway
     }
 
     fn status(&self) -> String {

--- a/src/models/processor.rs
+++ b/src/models/processor.rs
@@ -3,7 +3,7 @@ use std::f64::INFINITY;
 
 use serde::{Deserialize, Serialize};
 
-use super::model::Model;
+use super::model::{Model, Type};
 use super::ModelMessage;
 use crate::input_modeling::random_variable::ContinuousRandomVariable;
 use crate::input_modeling::uniform_rng::UniformRNG;
@@ -145,6 +145,10 @@ impl Model for Processor {
 
     fn id(&self) -> String {
         self.id.clone()
+    }
+
+    fn get_type(&self) -> Type {
+        Type::Processor
     }
 
     fn status(&self) -> String {

--- a/src/models/stochastic_gate.rs
+++ b/src/models/stochastic_gate.rs
@@ -3,7 +3,7 @@ use std::f64::INFINITY;
 
 use serde::{Deserialize, Serialize};
 
-use super::model::Model;
+use super::model::{Model, Type};
 use super::ModelMessage;
 use crate::input_modeling::random_variable::BooleanRandomVariable;
 use crate::input_modeling::uniform_rng::UniformRNG;
@@ -121,6 +121,10 @@ impl Model for StochasticGate {
 
     fn id(&self) -> String {
         self.id.clone()
+    }
+
+    fn get_type(&self) -> Type {
+        Type::StochasticGate
     }
 
     fn status(&self) -> String {

--- a/src/models/storage.rs
+++ b/src/models/storage.rs
@@ -3,7 +3,7 @@ use std::f64::INFINITY;
 
 use serde::{Deserialize, Serialize};
 
-use super::model::Model;
+use super::model::{Model, Type};
 use super::ModelMessage;
 use crate::input_modeling::uniform_rng::UniformRNG;
 use crate::utils::error::SimulationError;
@@ -108,6 +108,10 @@ impl Model for Storage {
 
     fn id(&self) -> String {
         self.id.clone()
+    }
+
+    fn get_type(&self) -> Type {
+        Type::Storage
     }
 
     fn status(&self) -> String {

--- a/src/simulator/test_simulations.rs
+++ b/src/simulator/test_simulations.rs
@@ -544,7 +544,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn simulation_serialization_deserialization_round_trip() {
         // Confirm a round trip deserialization-serialization
         let s_models = r#"


### PR DESCRIPTION
This creates a sort of intermediate representation with a `type` field added when serializing a `Box<dyn Model>` and then serializes that.

I'm not sure I'm happy with this, but it's the best workaround I could manage for now. I'll keep thinking about it. I'm hoping there's a better design for the whole (de)serialization story here.

The previously broken test now works!