### PR TITLE
serde implementation around enum & tag variant attribute

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ serde_yaml = "0.8"
 thiserror = "1.0"
 wasm-bindgen = "0.2.63"
 web-sys = { version = "0.3", features = [ "console" ] }
+enum_dispatch = "0.3.5"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires

--- a/src/models/exclusive_gateway.rs
+++ b/src/models/exclusive_gateway.rs
@@ -1,9 +1,8 @@
-use std::any::Any;
 use std::f64::INFINITY;
 
 use serde::{Deserialize, Serialize};
 
-use super::model::{Model, Type};
+use super::model::Model;
 use super::ModelMessage;
 use crate::input_modeling::random_variable::IndexRandomVariable;
 use crate::input_modeling::uniform_rng::UniformRNG;
@@ -102,16 +101,8 @@ impl ExclusiveGateway {
 }
 
 impl Model for ExclusiveGateway {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn id(&self) -> String {
         self.id.clone()
-    }
-
-    fn get_type(&self) -> Type {
-        Type::ExclusiveGateway
     }
 
     fn status(&self) -> String {

--- a/src/models/gate.rs
+++ b/src/models/gate.rs
@@ -1,9 +1,8 @@
-use std::any::Any;
 use std::f64::INFINITY;
 
 use serde::{Deserialize, Serialize};
 
-use super::model::{Model, Type};
+use super::model::Model;
 use super::ModelMessage;
 use crate::input_modeling::uniform_rng::UniformRNG;
 use crate::utils::error::SimulationError;
@@ -125,16 +124,8 @@ impl Gate {
 }
 
 impl Model for Gate {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn id(&self) -> String {
         self.id.clone()
-    }
-
-    fn get_type(&self) -> Type {
-        Type::Gate
     }
 
     fn status(&self) -> String {

--- a/src/models/generator.rs
+++ b/src/models/generator.rs
@@ -1,9 +1,8 @@
-use std::any::Any;
 use std::f64::INFINITY;
 
 use serde::{Deserialize, Serialize};
 
-use super::model::{Model, Type};
+use super::model::Model;
 use super::ModelMessage;
 use crate::input_modeling::random_variable::ContinuousRandomVariable;
 use crate::input_modeling::thinning::Thinning;
@@ -115,16 +114,8 @@ impl Generator {
 }
 
 impl Model for Generator {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn id(&self) -> String {
         self.id.clone()
-    }
-
-    fn get_type(&self) -> Type {
-        Type::Generator
     }
 
     fn status(&self) -> String {

--- a/src/models/load_balancer.rs
+++ b/src/models/load_balancer.rs
@@ -1,9 +1,8 @@
-use std::any::Any;
 use std::f64::INFINITY;
 
 use serde::{Deserialize, Serialize};
 
-use super::model::{Model, Type};
+use super::model::Model;
 use super::ModelMessage;
 use crate::input_modeling::uniform_rng::UniformRNG;
 use crate::utils::error::SimulationError;
@@ -101,16 +100,8 @@ impl LoadBalancer {
 }
 
 impl Model for LoadBalancer {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn id(&self) -> String {
         self.id.clone()
-    }
-
-    fn get_type(&self) -> Type {
-        Type::LoadBalancer
     }
 
     fn status(&self) -> String {

--- a/src/models/model.rs
+++ b/src/models/model.rs
@@ -18,14 +18,14 @@ use crate::utils::error::SimulationError;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum Type {
-    ExclusiveGateway(ExclusiveGateway),
-    Gate(Gate),
-    Generator(Generator),
-    LoadBalancer(LoadBalancer),
-    ParallelGateway(ParallelGateway),
-    Processor(Processor),
-    StochasticGate(StochasticGate),
-    Storage(Storage),
+    ExclusiveGateway,
+    Gate,
+    Generator,
+    LoadBalancer,
+    ParallelGateway,
+    Processor,
+    StochasticGate,
+    Storage,
 }
 
 /// The `Model` trait defines everything required for a model to operate

--- a/src/models/model.rs
+++ b/src/models/model.rs
@@ -1,10 +1,5 @@
-use std::any::Any;
-use std::fmt;
-
-use serde::de::value::MapAccessDeserializer;
-use serde::de::{self, MapAccess, Visitor};
-use serde::ser;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use enum_dispatch::enum_dispatch;
+use serde::{Deserialize, Serialize};
 
 use super::exclusive_gateway::ExclusiveGateway;
 use super::gate::Gate;
@@ -19,16 +14,18 @@ use crate::input_modeling::uniform_rng::UniformRNG;
 use crate::utils::error::SimulationError;
 
 /// The type of the Model.
-#[derive(Serialize, Clone, Copy)]
+#[enum_dispatch(Model)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
 pub enum Type {
-    ExclusiveGateway,
-    Gate,
-    Generator,
-    LoadBalancer,
-    ParallelGateway,
-    Processor,
-    StochasticGate,
-    Storage,
+    ExclusiveGateway(ExclusiveGateway),
+    Gate            (Gate),
+    Generator       (Generator),
+    LoadBalancer    (LoadBalancer),
+    ParallelGateway (ParallelGateway),
+    Processor       (Processor),
+    StochasticGate  (StochasticGate),
+    Storage         (Storage),
 }
 
 /// The `Model` trait defines everything required for a model to operate
@@ -36,10 +33,9 @@ pub enum Type {
 /// largely on the Discrete Event System Specification (DEVS), but with a
 /// small amount of plumbing (`as_any` and `id`) and a dedicated status
 /// reporting method `status`.
+#[enum_dispatch]
 pub trait Model {
-    fn as_any(&self) -> &dyn Any;
     fn id(&self) -> String;
-    fn get_type(&self) -> Type;
     fn status(&self) -> String;
     fn events_ext(
         &mut self,
@@ -54,160 +50,3 @@ pub trait Model {
     fn until_next_event(&self) -> f64;
 }
 
-impl Clone for Box<dyn Model> {
-    fn clone(&self) -> Self {
-        if let Some(exclusive_gateway) = self.as_any().downcast_ref::<ExclusiveGateway>() {
-            Box::new(exclusive_gateway.clone())
-        } else if let Some(gate) = self.as_any().downcast_ref::<Gate>() {
-            Box::new(gate.clone())
-        } else if let Some(generator) = self.as_any().downcast_ref::<Generator>() {
-            Box::new(generator.clone())
-        } else if let Some(load_balancer) = self.as_any().downcast_ref::<LoadBalancer>() {
-            Box::new(load_balancer.clone())
-        } else if let Some(parallel_gateway) = self.as_any().downcast_ref::<ParallelGateway>() {
-            Box::new(parallel_gateway.clone())
-        } else if let Some(processor) = self.as_any().downcast_ref::<Processor>() {
-            Box::new(processor.clone())
-        } else if let Some(stochastic_gate) = self.as_any().downcast_ref::<StochasticGate>() {
-            Box::new(stochastic_gate.clone())
-        } else if let Some(storage) = self.as_any().downcast_ref::<Storage>() {
-            Box::new(storage.clone())
-        } else {
-            panic!["Failed to clone component model"];
-        }
-    }
-}
-
-// TODO Consider typetag, instead of custom "dyn model"
-// serialization and deserialization, after:
-// https://github.com/dtolnay/typetag/issues/8
-// https://github.com/dtolnay/typetag/issues/15
-// https://github.com/dtolnay/typetag/pull/16
-
-/// A wrapper around a Model that injects the `type` field for serialization.
-#[derive(Serialize)]
-struct ModelSerializationRepresentation<'m, M: Model> {
-    r#type: Type,
-    #[serde(flatten)]
-    model: &'m M,
-}
-
-impl<'m, M: Model> ModelSerializationRepresentation<'m, M> {
-    fn new(model: &'m M) -> Self {
-        Self {
-            r#type: model.get_type(),
-            model,
-        }
-    }
-}
-
-impl Serialize for Box<dyn Model> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        if let Some(ref exclusive_gateway) = self.as_any().downcast_ref::<ExclusiveGateway>() {
-            ModelSerializationRepresentation::new(*exclusive_gateway).serialize(serializer)
-        } else if let Some(ref gate) = self.as_any().downcast_ref::<Gate>() {
-            ModelSerializationRepresentation::new(*gate).serialize(serializer)
-        } else if let Some(ref generator) = self.as_any().downcast_ref::<Generator>() {
-            ModelSerializationRepresentation::new(*generator).serialize(serializer)
-        } else if let Some(ref load_balancer) = self.as_any().downcast_ref::<LoadBalancer>() {
-            ModelSerializationRepresentation::new(*load_balancer).serialize(serializer)
-        } else if let Some(ref parallel_gateway) = self.as_any().downcast_ref::<ParallelGateway>() {
-            ModelSerializationRepresentation::new(*parallel_gateway).serialize(serializer)
-        } else if let Some(ref processor) = self.as_any().downcast_ref::<Processor>() {
-            ModelSerializationRepresentation::new(*processor).serialize(serializer)
-        } else if let Some(ref stochastic_gate) = self.as_any().downcast_ref::<StochasticGate>() {
-            ModelSerializationRepresentation::new(*stochastic_gate).serialize(serializer)
-        } else if let Some(ref storage) = self.as_any().downcast_ref::<Storage>() {
-            ModelSerializationRepresentation::new(*storage).serialize(serializer)
-        } else {
-            Err(ser::Error::custom(
-                "A model type was not recognized during serialization",
-            ))
-        }
-    }
-}
-
-struct ModelVisitor;
-
-impl<'de> Visitor<'de> for ModelVisitor {
-    type Value = Box<dyn Model>;
-
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("A software delivery simulator component model")
-    }
-
-    fn visit_map<V>(self, mut map: V) -> Result<Box<dyn Model>, V::Error>
-    where
-        V: MapAccess<'de>,
-    {
-        while let Some(key) = map.next_key::<String>()? {
-            match key.as_str() {
-                "type" => {
-                    let value = map.next_value::<String>()?;
-                    match value.as_str() {
-                        "ExclusiveGateway" => {
-                            return Ok(Box::new(ExclusiveGateway::deserialize(
-                                MapAccessDeserializer::new(map),
-                            )?));
-                        }
-                        "Gate" => {
-                            return Ok(Box::new(Gate::deserialize(MapAccessDeserializer::new(
-                                map,
-                            ))?));
-                        }
-                        "Generator" => {
-                            return Ok(Box::new(Generator::deserialize(
-                                MapAccessDeserializer::new(map),
-                            )?));
-                        }
-                        "LoadBalancer" => {
-                            return Ok(Box::new(LoadBalancer::deserialize(
-                                MapAccessDeserializer::new(map),
-                            )?));
-                        }
-                        "ParallelGateway" => {
-                            return Ok(Box::new(ParallelGateway::deserialize(
-                                MapAccessDeserializer::new(map),
-                            )?));
-                        }
-                        "Processor" => {
-                            return Ok(Box::new(Processor::deserialize(
-                                MapAccessDeserializer::new(map),
-                            )?));
-                        }
-                        "StochasticGate" => {
-                            return Ok(Box::new(StochasticGate::deserialize(
-                                MapAccessDeserializer::new(map),
-                            )?));
-                        }
-                        "Storage" => {
-                            return Ok(Box::new(Storage::deserialize(
-                                MapAccessDeserializer::new(map),
-                            )?));
-                        }
-                        &_ => {
-                            return Err(de::Error::custom(
-                                "A model type was not recognized during deserialization",
-                            ));
-                        }
-                    }
-                }
-                &_ => {}
-            }
-        }
-        Err(de::Error::custom("Failed to deserialize component model"))
-    }
-}
-
-impl<'de> Deserialize<'de> for Box<dyn Model> {
-    // TODO - Assumes the type field is at the beginning - make this order agnostic
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserializer.deserialize_any(ModelVisitor)
-    }
-}

--- a/src/models/model.rs
+++ b/src/models/model.rs
@@ -19,13 +19,13 @@ use crate::utils::error::SimulationError;
 #[serde(tag = "type")]
 pub enum Type {
     ExclusiveGateway(ExclusiveGateway),
-    Gate            (Gate),
-    Generator       (Generator),
-    LoadBalancer    (LoadBalancer),
-    ParallelGateway (ParallelGateway),
-    Processor       (Processor),
-    StochasticGate  (StochasticGate),
-    Storage         (Storage),
+    Gate(Gate),
+    Generator(Generator),
+    LoadBalancer(LoadBalancer),
+    ParallelGateway(ParallelGateway),
+    Processor(Processor),
+    StochasticGate(StochasticGate),
+    Storage(Storage),
 }
 
 /// The `Model` trait defines everything required for a model to operate
@@ -49,4 +49,3 @@ pub trait Model {
     fn time_advance(&mut self, time_delta: f64);
     fn until_next_event(&self) -> f64;
 }
-

--- a/src/models/parallel_gateway.rs
+++ b/src/models/parallel_gateway.rs
@@ -1,10 +1,9 @@
-use std::any::Any;
 use std::collections::HashMap;
 use std::f64::INFINITY;
 
 use serde::{Deserialize, Serialize};
 
-use super::model::{Model, Type};
+use super::model::Model;
 use super::ModelMessage;
 use crate::input_modeling::uniform_rng::UniformRNG;
 use crate::utils::error::SimulationError;
@@ -107,16 +106,8 @@ impl ParallelGateway {
 }
 
 impl Model for ParallelGateway {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn id(&self) -> String {
         self.id.clone()
-    }
-
-    fn get_type(&self) -> Type {
-        Type::ParallelGateway
     }
 
     fn status(&self) -> String {

--- a/src/models/processor.rs
+++ b/src/models/processor.rs
@@ -1,9 +1,8 @@
-use std::any::Any;
 use std::f64::INFINITY;
 
 use serde::{Deserialize, Serialize};
 
-use super::model::{Model, Type};
+use super::model::Model;
 use super::ModelMessage;
 use crate::input_modeling::random_variable::ContinuousRandomVariable;
 use crate::input_modeling::uniform_rng::UniformRNG;
@@ -139,16 +138,8 @@ impl Processor {
 }
 
 impl Model for Processor {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn id(&self) -> String {
         self.id.clone()
-    }
-
-    fn get_type(&self) -> Type {
-        Type::Processor
     }
 
     fn status(&self) -> String {

--- a/src/models/stochastic_gate.rs
+++ b/src/models/stochastic_gate.rs
@@ -1,9 +1,8 @@
-use std::any::Any;
 use std::f64::INFINITY;
 
 use serde::{Deserialize, Serialize};
 
-use super::model::{Model, Type};
+use super::model::Model;
 use super::ModelMessage;
 use crate::input_modeling::random_variable::BooleanRandomVariable;
 use crate::input_modeling::uniform_rng::UniformRNG;
@@ -115,16 +114,8 @@ impl StochasticGate {
 }
 
 impl Model for StochasticGate {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn id(&self) -> String {
         self.id.clone()
-    }
-
-    fn get_type(&self) -> Type {
-        Type::StochasticGate
     }
 
     fn status(&self) -> String {

--- a/src/models/storage.rs
+++ b/src/models/storage.rs
@@ -1,9 +1,8 @@
-use std::any::Any;
 use std::f64::INFINITY;
 
 use serde::{Deserialize, Serialize};
 
-use super::model::{Model, Type};
+use super::model::Model;
 use super::ModelMessage;
 use crate::input_modeling::uniform_rng::UniformRNG;
 use crate::utils::error::SimulationError;
@@ -102,16 +101,8 @@ impl Storage {
 }
 
 impl Model for Storage {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn id(&self) -> String {
         self.id.clone()
-    }
-
-    fn get_type(&self) -> Type {
-        Type::Storage
     }
 
     fn status(&self) -> String {

--- a/src/simulator/mod.rs
+++ b/src/simulator/mod.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
 use crate::input_modeling::uniform_rng::UniformRNG;
-use crate::models::model::Model;
+use crate::models::model::{Model, Type};
 use crate::models::ModelMessage;
 use crate::utils;
 use crate::utils::error::SimulationError;
@@ -36,7 +36,7 @@ mod test_simulations;
 #[derive(Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Simulation {
-    models: Vec<Box<dyn Model>>,
+    models: Vec<Type>,
     connectors: Vec<Connector>,
     messages: Vec<Message>,
     global_time: f64,
@@ -78,7 +78,7 @@ pub struct Message {
 impl Simulation {
     /// This constructor method creates a simulation from a supplied
     /// configuration (models and connectors).
-    pub fn post(models: Vec<Box<dyn Model>>, connectors: Vec<Connector>) -> Self {
+    pub fn post(models: Vec<Type>, connectors: Vec<Connector>) -> Self {
         utils::set_panic_hook();
         Self {
             models,
@@ -88,7 +88,7 @@ impl Simulation {
     }
 
     /// This method sets the models and connectors of an existing simulation.
-    pub fn put(&mut self, models: Vec<Box<dyn Model>>, connectors: Vec<Connector>) {
+    pub fn put(&mut self, models: Vec<Type>, connectors: Vec<Connector>) {
         self.models = models;
         self.connectors = connectors;
     }
@@ -142,7 +142,7 @@ impl Simulation {
 
     /// This method provides a convenient foundation for operating on the
     /// full set of models in the simulation.
-    pub fn models(&mut self) -> Vec<&mut Box<dyn Model>> {
+    pub fn models(&mut self) -> Vec<&mut Type> {
         self.models.iter_mut().collect()
     }
 

--- a/src/simulator/test_simulations.rs
+++ b/src/simulator/test_simulations.rs
@@ -450,7 +450,6 @@ fn processor_network_no_job_loss() {
 }
 
 #[test]
-// #[ignore]
 fn simulation_serialization_deserialization_field_ordering() {
     // Confirm field order does not matter for yaml deserialization
     let models = r#"

--- a/src/simulator/test_simulations.rs
+++ b/src/simulator/test_simulations.rs
@@ -450,7 +450,7 @@ fn processor_network_no_job_loss() {
 }
 
 #[test]
-#[ignore]
+// #[ignore]
 fn simulation_serialization_deserialization_field_ordering() {
     // Confirm field order does not matter for yaml deserialization
     let models = r#"
@@ -582,7 +582,7 @@ fn simulation_serialization_deserialization_round_trip() {
   sourcePort: "processed job"
   targetPort: "store"
 "#;
-    let models: Vec<Box<dyn Model>> = serde_yaml::from_str(s_models).unwrap();
+    let models: Vec<Type> = serde_yaml::from_str(s_models).unwrap();
     let connectors: Vec<Connector> = serde_yaml::from_str(s_connectors).unwrap();
     WebSimulation::post_yaml(
         &serde_yaml::to_string(&models).unwrap(),


### PR DESCRIPTION
another take on simplifying `serde` story and fixing issues with `type` field ordering on deserialization, as well as missing `type` field while serializing to json/yaml.
I've allowed myself to take inspiration from @uint 's awesome work located here https://github.com/ndebuhr/sim/pull/2 - `enum_dispatch` crate is the best thing since 21st century. Second part of this idea came from [`serde` docs](https://serde.rs/container-attrs.html#tag)

I feel like this change (`Vec<Box<dyn Model>>` changed to `Vec<Type>`) can drag substantial consequences, and I'm not sure if I'm getting the full picture, therefore I'd really appreciate if we could analyze this together to find potential shortcomings of this solution, to finally pick the one which makes the most sense. To me it looks like `enum_dispatch` is doing all necessary magic to reduce friction of using `enum` in such scenario, but it is ~4hrs since I began using it and I still haven't explored it's git issues section.