### PR TITLE
Add support for randomness customization

### DIFF
--- a/sim/Cargo.toml
+++ b/sim/Cargo.toml
@@ -22,6 +22,7 @@ getrandom = { version = "0.2", features = ["js"] }
 js-sys = "0.3"
 lazy_static = "1.4"
 num-traits = "0.2"
+rand_core = { version = "0.6", features = ["serde1"] }
 rand = { version = "0.8", features = ["serde1"] }
 rand_distr = { version = "0.4" }
 rand_pcg = { version = "0.3", features = ["serde1"] }

--- a/sim/src/input_modeling/mod.rs
+++ b/sim/src/input_modeling/mod.rs
@@ -13,4 +13,4 @@ pub use random_variable::Continuous as ContinuousRandomVariable;
 pub use random_variable::Discrete as DiscreteRandomVariable;
 pub use random_variable::Index as IndexRandomVariable;
 pub use thinning::Thinning;
-pub use uniform_rng::some_dyn_rng;
+pub use uniform_rng::{dyn_rng, some_dyn_rng};

--- a/sim/src/input_modeling/mod.rs
+++ b/sim/src/input_modeling/mod.rs
@@ -13,4 +13,4 @@ pub use random_variable::Continuous as ContinuousRandomVariable;
 pub use random_variable::Discrete as DiscreteRandomVariable;
 pub use random_variable::Index as IndexRandomVariable;
 pub use thinning::Thinning;
-pub use uniform_rng::UniformRNG;
+pub use uniform_rng::some_dyn_rng;

--- a/sim/src/input_modeling/uniform_rng.rs
+++ b/sim/src/input_modeling/uniform_rng.rs
@@ -8,6 +8,10 @@ pub(crate) fn default_rng() -> DynRng {
     Rc::new(RefCell::new(rand_pcg::Pcg64Mcg::new(42)))
 }
 
+pub fn dyn_rng<Rng: SimulationRng + 'static>(rng: Rng) -> DynRng {
+    Rc::new(RefCell::new(rng))
+}
+
 pub fn some_dyn_rng<Rng: SimulationRng + 'static>(rng: Rng) -> Option<DynRng> {
-    Some(Rc::new(RefCell::new(rng)))
+    Some(dyn_rng(rng))
 }

--- a/sim/src/input_modeling/uniform_rng.rs
+++ b/sim/src/input_modeling/uniform_rng.rs
@@ -1,56 +1,13 @@
-use rand::distributions::{Distribution, Uniform};
-use rand_pcg::Pcg64Mcg;
-use serde::{Deserialize, Serialize};
+use std::{cell::RefCell, rc::Rc};
 
-/// The random number generator used in simulations is a permuted
-/// congruential generator with 128-bit state, internal multiplicative
-/// congruential generator, and 64-bit output via "xorshift low (bits),
-/// random rotation" output function.  This random number generator is
-/// seeded and portable across platforms (e.g., WASM compilation targets).
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct UniformRNG {
-    rng: Pcg64Mcg,
+pub trait SimulationRng: std::fmt::Debug + rand_core::RngCore {}
+impl<T: std::fmt::Debug + rand_core::RngCore> SimulationRng for T {}
+pub type DynRng = Rc<RefCell<dyn SimulationRng>>;
+
+pub(crate) fn default_rng() -> DynRng {
+    Rc::new(RefCell::new(rand_pcg::Pcg64Mcg::new(42)))
 }
 
-impl Default for UniformRNG {
-    fn default() -> Self {
-        UniformRNG {
-            rng: Pcg64Mcg::new(42),
-        }
-    }
-}
-
-impl UniformRNG {
-    pub fn rn(&mut self) -> f64 {
-        // Random number in [0.0, 1.0)
-        Uniform::new(0.0_f64, 1.0_f64).sample(&mut self.rng)
-    }
-
-    pub fn rng(&mut self) -> &mut Pcg64Mcg {
-        &mut self.rng
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn generator_chi_square_uniformity_test() {
-        let mut uniform_rng = UniformRNG::default();
-        // 100 "classes" (bins)
-        let mut class_counts: [f64; 100] = [0.0; 100];
-        (0..100000).for_each(|_| {
-            let rn = uniform_rng.rn();
-            class_counts[(rn * 100.0) as usize] += 1.0;
-        });
-        let expected_count = 1000.0; // 100000 points, 100 classes, 10000 points per class
-        let chi_square = class_counts.iter().fold(0.0, |acc, class_count| {
-            acc + (*class_count - expected_count).powi(2) / expected_count
-        });
-        // At a significance level of 0.01, and with n-1=99 degrees of freedom, the chi square critical
-        // value for this scenario is 134.642
-        let chi_square_critical = 134.642;
-        assert![chi_square < chi_square_critical];
-    }
+pub fn some_dyn_rng<Rng: SimulationRng + 'static>(rng: Rng) -> Option<DynRng> {
+    Some(Rc::new(RefCell::new(rng)))
 }

--- a/sim/src/simulator/mod.rs
+++ b/sim/src/simulator/mod.rs
@@ -14,10 +14,13 @@
 //! return the messages generated during the execution of the simulation
 //! step(s), for use in message analysis.
 
+use std::cell::RefCell;
 use std::f64::INFINITY;
+use std::rc::Rc;
 
 use serde::{Deserialize, Serialize};
 
+use crate::input_modeling::uniform_rng::SimulationRng;
 use crate::models::{DevsModel, Model, ModelMessage, ModelRecord, Reportable};
 use crate::utils::errors::SimulationError;
 use crate::utils::set_panic_hook;
@@ -51,6 +54,25 @@ impl Simulation {
         Self {
             models,
             connectors,
+            ..Self::default()
+        }
+    }
+
+    /// This constructor method creates a simulation from a supplied
+    /// configuration (models and connectors).
+    pub fn post_with_rng(
+        models: Vec<Model>,
+        connectors: Vec<Connector>,
+        global_rng: impl SimulationRng + 'static,
+    ) -> Self {
+        set_panic_hook();
+        Self {
+            models,
+            connectors,
+            services: Services {
+                global_rng: Rc::new(RefCell::new(global_rng)),
+                global_time: 0.0,
+            },
             ..Self::default()
         }
     }

--- a/sim/src/simulator/mod.rs
+++ b/sim/src/simulator/mod.rs
@@ -21,6 +21,7 @@ use std::rc::Rc;
 use serde::{Deserialize, Serialize};
 
 use crate::input_modeling::uniform_rng::SimulationRng;
+use crate::input_modeling::{dyn_rng, some_dyn_rng};
 use crate::models::{DevsModel, Model, ModelMessage, ModelRecord, Reportable};
 use crate::utils::errors::SimulationError;
 use crate::utils::set_panic_hook;
@@ -70,11 +71,15 @@ impl Simulation {
             models,
             connectors,
             services: Services {
-                global_rng: Rc::new(RefCell::new(global_rng)),
+                global_rng: dyn_rng(global_rng),
                 global_time: 0.0,
             },
             ..Self::default()
         }
+    }
+
+    pub fn set_rng(&mut self, rng: impl SimulationRng + 'static) {
+        self.services.global_rng = dyn_rng(rng)
     }
 
     /// This method sets the models and connectors of an existing simulation.

--- a/sim/src/simulator/services.rs
+++ b/sim/src/simulator/services.rs
@@ -1,20 +1,29 @@
 use serde::{Deserialize, Serialize};
 
-use crate::input_modeling::UniformRNG;
+use crate::input_modeling::uniform_rng::{default_rng, DynRng};
 
 /// The simulator provides a uniform random number generator and simulation
 /// clock to models during the execution of a simulation
-#[derive(Clone, Default, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Services {
-    #[serde(skip_serializing)]
-    uniform_rng: UniformRNG,
-    global_time: f64,
+    #[serde(skip, default = "default_rng")]
+    pub(crate) global_rng: DynRng,
+    pub(crate) global_time: f64,
+}
+
+impl Default for Services {
+    fn default() -> Self {
+        Self {
+            global_rng: default_rng(),
+            global_time: 0.0,
+        }
+    }
 }
 
 impl Services {
-    pub fn uniform_rng(&mut self) -> &mut UniformRNG {
-        &mut self.uniform_rng
+    pub fn global_rng(&self) -> DynRng {
+        self.global_rng.clone()
     }
 
     pub fn global_time(&self) -> f64 {


### PR DESCRIPTION
Instead of forcing `Pcg64Mcg`. This PR adds ability to pass in a custom random generator for each model component (Generator, Excl. Gateway, Stochastic Gate, Processor), if None is provided a global rng will be used as previously.

I'm using `Rc<RefCell<dyn Debug + RngCore>>` for storage which is required because of possible type variance of rng's in  `Model` structs (generics wouldn't work; requires variadic generics). As a side effect, this allows multiple Models to share the same rng.

I tested a simulation using this change and it didn't break. Not sure about performance impact, but simulation performance should be a bit worse because of the added *jump* and *vtable lookup* each time rng was previously used.
Let me know whether there's anything you'd like to change/improve in what I've done in this PR so far, or it's okay as it is.

Before merging I'd like to rename `uniform_rng.rs` to something else, or possibly move its contents to parent `mod.rs`. I'd appreciate your opinion on this.

## Maybe unwanted changes
- `Services` struct now **skips deserializing** the randomness source as well (and constructs the default).
  - Given that any `RngCore` struct can be the global rng doesn't make sense to deserialize it anyway. Manually calling the (currently non-existant) rng setter seems like a better option.